### PR TITLE
Add single custom cloud support

### DIFF
--- a/Assets/VolumetricClouds/Editor/VolumetricCloudsVolumeEditor.cs
+++ b/Assets/VolumetricClouds/Editor/VolumetricCloudsVolumeEditor.cs
@@ -56,6 +56,10 @@ class VolumetricCloudsEditor : VolumeComponentEditor
     SerializedDataParameter m_ShapeFactor;
     SerializedDataParameter m_ShapeScale;
     SerializedDataParameter m_ShapeOffset;
+    SerializedDataParameter m_CustomCloudTexture;
+    SerializedDataParameter m_CustomCloudCenter;
+    SerializedDataParameter m_CustomCloudSize;
+    SerializedDataParameter m_UseCustomCloudTexture;
     SerializedDataParameter m_EarthCurvature;
     // Erosion
     SerializedDataParameter m_ErosionFactor;
@@ -163,6 +167,10 @@ class VolumetricCloudsEditor : VolumeComponentEditor
         m_ShapeFactor = Unpack(o.Find(x => x.shapeFactor));
         m_ShapeScale = Unpack(o.Find(x => x.shapeScale));
         m_ShapeOffset = Unpack(o.Find(x => x.shapeOffset));
+        m_CustomCloudTexture = Unpack(o.Find(x => x.customCloudTexture));
+        m_CustomCloudCenter = Unpack(o.Find(x => x.customCloudCenter));
+        m_CustomCloudSize = Unpack(o.Find(x => x.customCloudSize));
+        m_UseCustomCloudTexture = Unpack(o.Find(x => x.useCustomCloudTexture));
         m_EarthCurvature = Unpack(o.Find(x => x.earthCurvature));
         m_ErosionFactor = Unpack(o.Find(x => x.erosionFactor));
         m_ErosionScale = Unpack(o.Find(x => x.erosionScale));
@@ -605,6 +613,16 @@ class VolumetricCloudsEditor : VolumeComponentEditor
 
         // Additional properties
         PropertyField(m_ShapeOffset);
+        PropertyField(m_UseCustomCloudTexture);
+        PropertyField(m_CustomCloudTexture);
+        if (m_CustomCloudTexture.value.objectReferenceValue != null)
+        {
+            using (new IndentLevelScope())
+            {
+                PropertyField(m_CustomCloudCenter);
+                PropertyField(m_CustomCloudSize);
+            }
+        }
 
     #if URP_PBSKY
         if (hasVisualEnvVolume) { EditorGUILayout.HelpBox(k_EarthCurvatureMessage, MessageType.Info, wide: true);}

--- a/Assets/VolumetricClouds/VolumetricClouds.shader
+++ b/Assets/VolumetricClouds/VolumetricClouds.shader
@@ -6,6 +6,9 @@ Shader "Hidden/Sky/VolumetricClouds"
         [HideInInspector][NoScaleOffset] _CloudCurveTexture("Cloud LUT Curve Texture", 2D) = "white" {}
         [NoScaleOffset] _ErosionNoise("Erosion Noise Texture", 3D) = "white" {}
         [NoScaleOffset] _Worley128RGBA("Worley Noise Texture", 3D) = "white" {}
+        [NoScaleOffset] _CustomCloudTexture("Custom Cloud Texture", 3D) = "" {}
+        _CustomCloudCenter("Custom Cloud Center", Vector) = (0,0,0,0)
+        _CustomCloudSize("Custom Cloud Size", Vector) = (1,1,1,0)
         [HideInInspector] _Seed("Private: Random Seed", Float) = 0.0
         [HideInInspector] _VolumetricCloudsAmbientProbe("Ambient Probe", CUBE) = "grey" {}
         [HideInInspector] _NumPrimarySteps("Ray Steps", Float) = 32.0
@@ -78,8 +81,9 @@ Shader "Hidden/Sky/VolumetricClouds"
             
             TEXTURE2D(_CloudLutTexture);
             TEXTURE2D(_CloudCurveTexture);
-            TEXTURE3D(_Worley128RGBA);
-            TEXTURE3D(_ErosionNoise);
+           TEXTURE3D(_Worley128RGBA);
+           TEXTURE3D(_ErosionNoise);
+            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_point_clamp_sampler);
@@ -93,6 +97,7 @@ Shader "Hidden/Sky/VolumetricClouds"
             #pragma multi_compile_local_fragment _ _OUTPUT_CLOUDS_DEPTH
             #pragma multi_compile_local_fragment _ _PHYSICALLY_BASED_SUN
             #pragma multi_compile_local_fragment _ _PERCEPTUAL_BLENDING
+            #pragma multi_compile_local_fragment _ _CUSTOM_CLOUD_TEXTURE
 
             #include "./VolumetricClouds.hlsl"
 
@@ -419,6 +424,7 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
             TEXTURE3D(_Worley128RGBA);
             TEXTURE3D(_ErosionNoise);
+            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_linear_repeat_sampler);
@@ -461,6 +467,7 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
             TEXTURE3D(_Worley128RGBA);
             TEXTURE3D(_ErosionNoise);
+            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_linear_repeat_sampler);
@@ -658,6 +665,7 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
             TEXTURE3D(_Worley128RGBA);
             TEXTURE3D(_ErosionNoise);
+            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_point_clamp_sampler);

--- a/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
@@ -26,6 +26,8 @@ half _ErosionFactor;
 half _ErosionOcclusion;
 half _MicroErosionScale;
 half _MicroErosionFactor;
+float3 _CustomCloudCenter;
+float3 _CustomCloudSize;
 half _FadeInStart;
 half _FadeInDistance;
 half _MultiScattering;

--- a/Assets/VolumetricClouds/VolumetricCloudsURP.cs
+++ b/Assets/VolumetricClouds/VolumetricCloudsURP.cs
@@ -438,6 +438,9 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
         private static readonly int erosionOcclusion = Shader.PropertyToID("_ErosionOcclusion");
         private static readonly int microErosionScale = Shader.PropertyToID("_MicroErosionScale");
         private static readonly int microErosionFactor = Shader.PropertyToID("_MicroErosionFactor");
+        private static readonly int customCloudTexture = Shader.PropertyToID("_CustomCloudTexture");
+        private static readonly int customCloudCenter = Shader.PropertyToID("_CustomCloudCenter");
+        private static readonly int customCloudSize = Shader.PropertyToID("_CustomCloudSize");
         private static readonly int fadeInStart = Shader.PropertyToID("_FadeInStart");
         private static readonly int fadeInDistance = Shader.PropertyToID("_FadeInDistance");
         private static readonly int multiScattering = Shader.PropertyToID("_MultiScattering");
@@ -471,6 +474,7 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
 
         private const string localClouds = "_LOCAL_VOLUMETRIC_CLOUDS";
         private const string microErosion = "_CLOUDS_MICRO_EROSION";
+        private const string customCloudKeyword = "_CUSTOM_CLOUD_TEXTURE";
         private const string lowResClouds = "_LOW_RESOLUTION_CLOUDS";
         private const string cloudsAmbientProbe = "_CLOUDS_AMBIENT_PROBE";
         private const string outputCloudsDepth = "_OUTPUT_CLOUDS_DEPTH";
@@ -623,6 +627,17 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
             cloudsMaterial.SetFloat(erosionOcclusion, cloudsVolume.erosionOcclusion.value);
             cloudsMaterial.SetFloat(microErosionScale, cloudsVolume.microErosionScale.value);
             cloudsMaterial.SetFloat(microErosionFactor, cloudsVolume.microErosionFactor.value);
+            if (cloudsVolume.customCloudTexture.value != null && cloudsVolume.useCustomCloudTexture.value)
+            {
+                cloudsMaterial.EnableKeyword(customCloudKeyword);
+                cloudsMaterial.SetTexture(customCloudTexture, cloudsVolume.customCloudTexture.value);
+                cloudsMaterial.SetVector(customCloudCenter, cloudsVolume.customCloudCenter.value);
+                cloudsMaterial.SetVector(customCloudSize, cloudsVolume.customCloudSize.value);
+            }
+            else
+            {
+                cloudsMaterial.DisableKeyword(customCloudKeyword);
+            }
 
             bool autoFadeIn = cloudsVolume.fadeInMode.value == VolumetricClouds.CloudFadeInMode.Automatic;
             cloudsMaterial.SetFloat(fadeInStart, autoFadeIn ? Mathf.Max(cloudsVolume.altitudeRange.value * 0.2f, camera.nearClipPlane) : Mathf.Max(cloudsVolume.fadeInStart.value, camera.nearClipPlane));

--- a/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
@@ -6,6 +6,10 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
 
+TEXTURE3D(_CustomCloudTexture);
+float3 _CustomCloudCenter;
+float3 _CustomCloudSize;
+
 half3 EvaluateVolumetricCloudsAmbientProbe(half3 normalWS)
 {
     // Linear + constant polynomial terms
@@ -416,6 +420,12 @@ void EvaluateCloudProperties(float3 positionPS, float noiseMipOffset, float eros
     // When rendering in camera space, we still want horizontal scrolling
 #ifndef _LOCAL_VOLUMETRIC_CLOUDS
     positionPS.xz += _WorldSpaceCameraPos.xz;
+#endif
+
+#ifdef _CUSTOM_CLOUD_TEXTURE
+    float3 localPos = (positionPS - _CustomCloudCenter) / _CustomCloudSize;
+    properties.density = SAMPLE_TEXTURE3D_LOD(_CustomCloudTexture, s_trilinear_repeat_sampler, localPos, 0).r;
+    return;
 #endif
 
     // Evaluate the generic sampling coordinates

--- a/Assets/VolumetricClouds/VolumetricCloudsVolume.cs
+++ b/Assets/VolumetricClouds/VolumetricCloudsVolume.cs
@@ -117,6 +117,31 @@ public class VolumetricClouds : VolumeComponent, IPostProcessComponent
     public Vector3Parameter shapeOffset = new(Vector3.zero);
 
     /// <summary>
+    /// Optional custom 3D texture defining a single cloud density.
+    /// </summary>
+    [Tooltip("Optional custom 3D texture defining a single cloud density.")]
+    public Texture3DParameter customCloudTexture = new(null);
+
+    /// <summary>
+    /// World space center position of the custom cloud.
+    /// </summary>
+    [Tooltip("World space center position of the custom cloud.")]
+    public Vector3Parameter customCloudCenter = new(Vector3.zero);
+
+    /// <summary>
+    /// Size of the custom cloud in meters.
+    /// </summary>
+    [Tooltip("Size of the custom cloud in meters.")]
+    public Vector3Parameter customCloudSize = new(Vector3.one * 1000f);
+
+    /// <summary>
+    /// Enable rendering of the custom single cloud texture.
+    /// </summary>
+    [AdditionalProperty]
+    [Tooltip("Enable rendering of the custom single cloud texture.")]
+    public BoolParameter useCustomCloudTexture = new(false);
+
+    /// <summary>
     /// Controls the curvature of the cloud volume which defines the distance at which the clouds intersect with the horizon.
     /// </summary>
     [Tooltip("Controls the curvature of the cloud volume which defines the distance at which the clouds intersect with the horizon.")]

--- a/Documentation/Setup.md
+++ b/Documentation/Setup.md
@@ -21,3 +21,11 @@ Setup
 - Adjust the settings in URP Volume and use different Volume types (global and local) to control volumetric clouds if needed.
 
 - On platforms that don't implement reversed-z (ex. OpenGL), please keep the camera near plane (ex. 0.1) high to avoid depth precision issues.
+
+Single Cloud Mode
+-----------------
+
+The volume override exposes a **Custom Cloud Texture** field for rendering a single high-detail cloud.
+Import a `Texture3D` asset into the project and assign it to this field.
+When a texture is provided, use **Custom Cloud Center** and **Custom Cloud Size** to position the cloud in world space.
+Enable **Use Custom Cloud Texture** to activate the feature.


### PR DESCRIPTION
## Summary
- expose custom cloud texture fields in `VolumetricCloudsVolume`
- show new fields in the volume override inspector
- hook up shader properties and keyword in renderer feature
- support `_CUSTOM_CLOUD_TEXTURE` in shader and utilities
- document how to use single cloud mode

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686babb011d483219e78d68c9396d72b