### PR TITLE
Fix custom cloud center planet-space conversion

### DIFF
--- a/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
@@ -423,7 +423,9 @@ void EvaluateCloudProperties(float3 positionPS, float noiseMipOffset, float eros
 #endif
 
 #ifdef _CUSTOM_CLOUD_TEXTURE
-    float3 localPos = (positionPS - _CustomCloudCenter) / _CustomCloudSize;
+    // Convert the custom cloud center from world space to planet space
+    float3 customCenterPS = ConvertToPS(_CustomCloudCenter);
+    float3 localPos = (positionPS - customCenterPS) / _CustomCloudSize;
     properties.density = SAMPLE_TEXTURE3D_LOD(_CustomCloudTexture, s_trilinear_repeat_sampler, localPos, 0).r;
     return;
 #endif

--- a/Assets/VolumetricClouds/VolumetricCloudsVolume.cs
+++ b/Assets/VolumetricClouds/VolumetricCloudsVolume.cs
@@ -123,9 +123,10 @@ public class VolumetricClouds : VolumeComponent, IPostProcessComponent
     public Texture3DParameter customCloudTexture = new(null);
 
     /// <summary>
-    /// World space center position of the custom cloud.
+    /// World space center position of the custom cloud. This value is converted
+    /// to planet space internally before sampling the texture.
     /// </summary>
-    [Tooltip("World space center position of the custom cloud.")]
+    [Tooltip("World space center position of the custom cloud. This value is converted to planet space internally before sampling.")]
     public Vector3Parameter customCloudCenter = new(Vector3.zero);
 
     /// <summary>


### PR DESCRIPTION
## Summary
- convert custom cloud center to planet space before sampling
- document that custom cloud center is specified in world space

## Testing
- `apt-get update`
- `apt-get install -y glslc clang`
- `glslc Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl -o /tmp/out.spv` *(fails: cannot find include files)*

------
https://chatgpt.com/codex/tasks/task_e_686bf54bb8a483219acb902c12e0773a