### PR TITLE
Fix custom cloud texture declaration

### DIFF
--- a/Assets/VolumetricClouds/VolumetricClouds.shader
+++ b/Assets/VolumetricClouds/VolumetricClouds.shader
@@ -83,7 +83,6 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
            TEXTURE3D(_Worley128RGBA);
            TEXTURE3D(_ErosionNoise);
-            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_point_clamp_sampler);
@@ -424,7 +423,6 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
             TEXTURE3D(_Worley128RGBA);
             TEXTURE3D(_ErosionNoise);
-            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_linear_repeat_sampler);
@@ -467,7 +465,6 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
             TEXTURE3D(_Worley128RGBA);
             TEXTURE3D(_ErosionNoise);
-            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_linear_repeat_sampler);
@@ -665,7 +662,6 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
             TEXTURE3D(_Worley128RGBA);
             TEXTURE3D(_ErosionNoise);
-            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_point_clamp_sampler);

--- a/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
@@ -28,6 +28,7 @@ half _MicroErosionScale;
 half _MicroErosionFactor;
 float3 _CustomCloudCenter;
 float3 _CustomCloudSize;
+TEXTURE3D(_CustomCloudTexture);
 half _FadeInStart;
 half _FadeInDistance;
 half _MultiScattering;

--- a/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
@@ -6,7 +6,6 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
 
-TEXTURE3D(_CustomCloudTexture);
 float3 _CustomCloudCenter;
 float3 _CustomCloudSize;
 


### PR DESCRIPTION
## Summary
- centralize `_CustomCloudTexture` definition in `VolumetricCloudsDefs.hlsl`
- remove repeated `TEXTURE3D(_CustomCloudTexture)` statements from shader and utilities

## Testing
- `grep -R "TEXTURE3D(_CustomCloudTexture)" -n`


------
https://chatgpt.com/codex/tasks/task_e_686c01031934832193853f0138a02605