### PR TITLE
Fix custom cloud texture declaration

### DIFF
--- a/Assets/VolumetricClouds/VolumetricClouds.shader
+++ b/Assets/VolumetricClouds/VolumetricClouds.shader
@@ -83,7 +83,6 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
            TEXTURE3D(_Worley128RGBA);
            TEXTURE3D(_ErosionNoise);
-            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_point_clamp_sampler);
@@ -424,7 +423,6 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
             TEXTURE3D(_Worley128RGBA);
             TEXTURE3D(_ErosionNoise);
-            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_linear_repeat_sampler);
@@ -467,7 +465,6 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
             TEXTURE3D(_Worley128RGBA);
             TEXTURE3D(_ErosionNoise);
-            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_linear_repeat_sampler);
@@ -665,7 +662,6 @@ Shader "Hidden/Sky/VolumetricClouds"
             TEXTURE2D(_CloudCurveTexture);
             TEXTURE3D(_Worley128RGBA);
             TEXTURE3D(_ErosionNoise);
-            TEXTURE3D(_CustomCloudTexture);
             TEXTURECUBE(_VolumetricCloudsAmbientProbe);
 
             SAMPLER(s_point_clamp_sampler);

--- a/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
@@ -40,6 +40,8 @@ half _NormalizationFactor;
 half _CloudNearPlane;
 CBUFFER_END
 
+TEXTURE3D(_CustomCloudTexture);
+
 // Ambient Probe (unity_SH)
 half4 clouds_SHAr;
 half4 clouds_SHAg;
@@ -56,5 +58,4 @@ half3 _SunColor;
 #ifndef URP_PHYSICALLY_BASED_SKY_DEFINES_INCLUDED
 float4 _PlanetCenterRadius;
 #endif
-
 #endif

--- a/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
@@ -6,10 +6,6 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
 
-TEXTURE3D(_CustomCloudTexture);
-float3 _CustomCloudCenter;
-float3 _CustomCloudSize;
-
 half3 EvaluateVolumetricCloudsAmbientProbe(half3 normalWS)
 {
     // Linear + constant polynomial terms


### PR DESCRIPTION
## Summary
- move the custom cloud texture resource outside the constant buffer so Metal shader compilation succeeds

## Testing
- `grep -R "TEXTURE3D(_CustomCloudTexture)" -n`


------
https://chatgpt.com/codex/tasks/task_e_686c01031934832193853f0138a02605