### PR TITLE
Fix custom cloud scattering

### DIFF
--- a/Assets/VolumetricClouds/Editor/VolumetricCloudsVolumeEditor.cs
+++ b/Assets/VolumetricClouds/Editor/VolumetricCloudsVolumeEditor.cs
@@ -60,6 +60,7 @@ class VolumetricCloudsEditor : VolumeComponentEditor
     SerializedDataParameter m_CustomCloudCenter;
     SerializedDataParameter m_CustomCloudSize;
     SerializedDataParameter m_UseCustomCloudTexture;
+    SerializedDataParameter m_CustomCloudSigmaT;
     SerializedDataParameter m_EarthCurvature;
     // Erosion
     SerializedDataParameter m_ErosionFactor;
@@ -171,6 +172,7 @@ class VolumetricCloudsEditor : VolumeComponentEditor
         m_CustomCloudCenter = Unpack(o.Find(x => x.customCloudCenter));
         m_CustomCloudSize = Unpack(o.Find(x => x.customCloudSize));
         m_UseCustomCloudTexture = Unpack(o.Find(x => x.useCustomCloudTexture));
+        m_CustomCloudSigmaT = Unpack(o.Find(x => x.customCloudSigmaT));
         m_EarthCurvature = Unpack(o.Find(x => x.earthCurvature));
         m_ErosionFactor = Unpack(o.Find(x => x.erosionFactor));
         m_ErosionScale = Unpack(o.Find(x => x.erosionScale));
@@ -621,6 +623,7 @@ class VolumetricCloudsEditor : VolumeComponentEditor
             {
                 PropertyField(m_CustomCloudCenter);
                 PropertyField(m_CustomCloudSize);
+                PropertyField(m_CustomCloudSigmaT);
             }
         }
 

--- a/Assets/VolumetricClouds/VolumetricClouds.shader
+++ b/Assets/VolumetricClouds/VolumetricClouds.shader
@@ -9,6 +9,7 @@ Shader "Hidden/Sky/VolumetricClouds"
         [NoScaleOffset] _CustomCloudTexture("Custom Cloud Texture", 3D) = "" {}
         _CustomCloudCenter("Custom Cloud Center", Vector) = (0,0,0,0)
         _CustomCloudSize("Custom Cloud Size", Vector) = (1,1,1,0)
+        [HideInInspector] _CustomCloudSigmaT("Custom Cloud SigmaT", Float) = 0.06
         [HideInInspector] _Seed("Private: Random Seed", Float) = 0.0
         [HideInInspector] _VolumetricCloudsAmbientProbe("Ambient Probe", CUBE) = "grey" {}
         [HideInInspector] _NumPrimarySteps("Ray Steps", Float) = 32.0

--- a/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
@@ -29,6 +29,7 @@ half _MicroErosionFactor;
 float3 _CustomCloudCenter;
 float3 _CustomCloudSize;
 TEXTURE3D(_CustomCloudTexture);
+half _CustomCloudSigmaT;
 half _FadeInStart;
 half _FadeInDistance;
 half _MultiScattering;

--- a/Assets/VolumetricClouds/VolumetricCloudsURP.cs
+++ b/Assets/VolumetricClouds/VolumetricCloudsURP.cs
@@ -441,6 +441,7 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
         private static readonly int customCloudTexture = Shader.PropertyToID("_CustomCloudTexture");
         private static readonly int customCloudCenter = Shader.PropertyToID("_CustomCloudCenter");
         private static readonly int customCloudSize = Shader.PropertyToID("_CustomCloudSize");
+        private static readonly int customCloudSigmaT = Shader.PropertyToID("_CustomCloudSigmaT");
         private static readonly int fadeInStart = Shader.PropertyToID("_FadeInStart");
         private static readonly int fadeInDistance = Shader.PropertyToID("_FadeInDistance");
         private static readonly int multiScattering = Shader.PropertyToID("_MultiScattering");
@@ -633,6 +634,7 @@ public class VolumetricCloudsURP : ScriptableRendererFeature
                 cloudsMaterial.SetTexture(customCloudTexture, cloudsVolume.customCloudTexture.value);
                 cloudsMaterial.SetVector(customCloudCenter, cloudsVolume.customCloudCenter.value);
                 cloudsMaterial.SetVector(customCloudSize, cloudsVolume.customCloudSize.value);
+                cloudsMaterial.SetFloat(customCloudSigmaT, cloudsVolume.customCloudSigmaT.value);
             }
             else
             {

--- a/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
@@ -425,6 +425,7 @@ void EvaluateCloudProperties(float3 positionPS, float noiseMipOffset, float eros
     float3 customCenterPS = ConvertToPS(_CustomCloudCenter);
     float3 localPos = (positionPS - customCenterPS) / _CustomCloudSize;
     properties.density = SAMPLE_TEXTURE3D_LOD(_CustomCloudTexture, s_trilinear_repeat_sampler, localPos, 0).r;
+    properties.sigmaT = _CustomCloudSigmaT;
     return;
 #endif
 

--- a/Assets/VolumetricClouds/VolumetricCloudsVolume.cs
+++ b/Assets/VolumetricClouds/VolumetricCloudsVolume.cs
@@ -143,6 +143,13 @@ public class VolumetricClouds : VolumeComponent, IPostProcessComponent
     public BoolParameter useCustomCloudTexture = new(false);
 
     /// <summary>
+    /// Extinction coefficient applied when sampling the custom cloud texture.
+    /// </summary>
+    [AdditionalProperty]
+    [Tooltip("Extinction coefficient applied when sampling the custom cloud texture.")]
+    public ClampedFloatParameter customCloudSigmaT = new(0.06f, 0.0f, 1.0f);
+
+    /// <summary>
     /// Controls the curvature of the cloud volume which defines the distance at which the clouds intersect with the horizon.
     /// </summary>
     [Tooltip("Controls the curvature of the cloud volume which defines the distance at which the clouds intersect with the horizon.")]


### PR DESCRIPTION
## Summary
- add `_CustomCloudSigmaT` property and shader parameter
- assign sigmaT when sampling custom cloud texture
- expose `customCloudSigmaT` in `VolumetricCloudsVolume`
- plumb new parameter through URP material and editor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686da01e3de08321a52f106f5e317ecb