### PR TITLE
Add clamp sampler and update custom cloud sampling

### DIFF
--- a/Assets/VolumetricClouds/VolumetricClouds.shader
+++ b/Assets/VolumetricClouds/VolumetricClouds.shader
@@ -89,6 +89,7 @@ Shader "Hidden/Sky/VolumetricClouds"
             SAMPLER(s_point_clamp_sampler);
             SAMPLER(s_linear_repeat_sampler);
             SAMPLER(s_trilinear_repeat_sampler);
+            SAMPLER(s_trilinear_clamp_sampler);
             SAMPLER(sampler_VolumetricCloudsAmbientProbe);
 
             #pragma multi_compile_local_fragment _ _CLOUDS_MICRO_EROSION
@@ -428,6 +429,7 @@ Shader "Hidden/Sky/VolumetricClouds"
 
             SAMPLER(s_linear_repeat_sampler);
             SAMPLER(s_trilinear_repeat_sampler);
+            SAMPLER(s_trilinear_clamp_sampler);
             SAMPLER(sampler_VolumetricCloudsAmbientProbe);
 
             TEXTURE2D_X(_VolumetricCloudsLightingTexture);
@@ -470,6 +472,7 @@ Shader "Hidden/Sky/VolumetricClouds"
 
             SAMPLER(s_linear_repeat_sampler);
             SAMPLER(s_trilinear_repeat_sampler);
+            SAMPLER(s_trilinear_clamp_sampler);
             SAMPLER(sampler_VolumetricCloudsAmbientProbe);
             
             TEXTURE2D_X(_VolumetricCloudsLightingTexture);
@@ -668,6 +671,7 @@ Shader "Hidden/Sky/VolumetricClouds"
             SAMPLER(s_point_clamp_sampler);
             SAMPLER(s_linear_repeat_sampler);
             SAMPLER(s_trilinear_repeat_sampler);
+            SAMPLER(s_trilinear_clamp_sampler);
             SAMPLER(sampler_VolumetricCloudsAmbientProbe);
 
             // Note: This pass doesn't need to support dynamic resolution

--- a/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
@@ -423,8 +423,10 @@ void EvaluateCloudProperties(float3 positionPS, float noiseMipOffset, float eros
 #ifdef _CUSTOM_CLOUD_TEXTURE
     // Convert the custom cloud center from world space to planet space
     float3 customCenterPS = ConvertToPS(_CustomCloudCenter);
-    float3 localPos = (positionPS - customCenterPS) / _CustomCloudSize;
-    properties.density = SAMPLE_TEXTURE3D_LOD(_CustomCloudTexture, s_trilinear_repeat_sampler, localPos, 0).r;
+    float3 texCoords = (positionPS - customCenterPS) / _CustomCloudSize + 0.5;
+    bool inside = all(texCoords >= 0.0) && all(texCoords <= 1.0);
+    properties.density = inside ? SAMPLE_TEXTURE3D_LOD(
+        _CustomCloudTexture, s_trilinear_clamp_sampler, texCoords, 0).r : 0.0;
     properties.sigmaT = _CustomCloudSigmaT;
     return;
 #endif


### PR DESCRIPTION
## Summary
- declare `s_trilinear_clamp_sampler` in all shader passes
- use clamp sampler and bounds check for custom cloud textures

## Testing
- `apt-get update`
- `apt-get install -y dxvk` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dcb2217a4832185fb96efd89381b8