### PR TITLE
Add camera offset to custom cloud center

### DIFF
--- a/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsDefs.hlsl
@@ -28,7 +28,7 @@ half _MicroErosionScale;
 half _MicroErosionFactor;
 float3 _CustomCloudCenter;
 float3 _CustomCloudSize;
-TEXTURE3D(_CustomCloudTexture);
+
 half _CustomCloudSigmaT;
 half _FadeInStart;
 half _FadeInDistance;
@@ -61,3 +61,4 @@ half3 _SunColor;
 float4 _PlanetCenterRadius;
 #endif
 
+#endif // URP_VOLUMETRIC_CLOUDS_DEFINES_HLSL

--- a/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
+++ b/Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl
@@ -423,6 +423,9 @@ void EvaluateCloudProperties(float3 positionPS, float noiseMipOffset, float eros
 #ifdef _CUSTOM_CLOUD_TEXTURE
     // Convert the custom cloud center from world space to planet space
     float3 customCenterPS = ConvertToPS(_CustomCloudCenter);
+#ifndef _LOCAL_VOLUMETRIC_CLOUDS
+    customCenterPS.xz += _WorldSpaceCameraPos.xz;
+#endif
     float3 localPos = (positionPS - customCenterPS) / _CustomCloudSize;
     properties.density = SAMPLE_TEXTURE3D_LOD(_CustomCloudTexture, s_trilinear_repeat_sampler, localPos, 0).r;
     properties.sigmaT = _CustomCloudSigmaT;


### PR DESCRIPTION
## Summary
- offset custom cloud center by camera position when not using local volumetric clouds

## Testing
- `glslangValidator -V Assets/VolumetricClouds/VolumetricCloudsUtilities.hlsl` *(fails: shows usage output)*

------
https://chatgpt.com/codex/tasks/task_e_686dd2e0969883218528946897fa87d7